### PR TITLE
WEBDEV-7382 Reduce max screenname length

### DIFF
--- a/.github/workflows/gh-pages-main.yml
+++ b/.github/workflows/gh-pages-main.yml
@@ -3,6 +3,8 @@
 # This workflow will run every time new changes were pushed to the `main` branch
 
 name: App build CI/CD to main branch
+permissions:
+  contents: write
 
 on:
   push:
@@ -29,11 +31,10 @@ jobs:
 
       # Reference: https://github.com/JamesIves/github-pages-deploy-action
       - name: Deploy 🚀
-        uses: JamesIves/github-pages-deploy-action@v4.4.1
+        uses: JamesIves/github-pages-deploy-action@v4.7.3
         with:
           branch: gh-pages
           folder: ghpages
           clean-exclude: pr/
           force: false
           target-folder: main
-          token: ${{ secrets.GH_TOKEN }}

--- a/src/ia-account-settings.ts
+++ b/src/ia-account-settings.ts
@@ -405,10 +405,10 @@ export class IAAccountSettings
 
     const invalidLength =
       this.userData.screenname.length < 3 ||
-      this.userData.screenname.length > 127;
+      this.userData.screenname.length > 40;
 
     if (this.userData.screenname === '' || invalidLength) {
-      error = 'The screen name needs to be between 3 and 127 characters long.';
+      error = 'The screen name needs to be between 3 and 40 characters long.';
     } else if (this.userData.screenname?.includes('\\')) {
       error = 'This does not appear to be a valid screen name.';
     } else if ((await this.isScreennameAvailable()) === false) {

--- a/test/ia-account-settings.test.ts
+++ b/test/ia-account-settings.test.ts
@@ -134,7 +134,7 @@ describe('IAAccountSettings', () => {
     // validation for password input field
     el.validateScreenname();
     expect(el.fieldsError.screenname).to.equal(
-      'The screen name needs to be between 3 and 127 characters long.'
+      'The screen name needs to be between 3 and 40 characters long.'
     );
 
     el.userData.screenname = 'neeraj\\sharma';


### PR DESCRIPTION
Reduces max screenname length to 40. Also bundles in a quick dependency/config update for deploys to main to prevent future breakage.