### PR TITLE
v0.2.8

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   },
   "license": "AGPL-3.0-only",
   "author": "Internet Archive",
-  "version": "0.2.7",
+  "version": "0.2.8",
   "main": "dist/index.js",
   "module": "dist/index.js",
   "scripts": {


### PR DESCRIPTION
Bumps version to v0.2.8. Includes `gh-pages` and README updates, along with updated screenname max length.