### PR TITLE
v1.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   },
   "license": "AGPL-3.0-only",
   "author": "Internet Archive",
-  "version": "0.2.8",
+  "version": "1.0.0",
   "main": "dist/index.js",
   "module": "dist/index.js",
   "scripts": {


### PR DESCRIPTION
Bumps to `1.0.0` following the [template guidance](https://github.com/internetarchive/iaux-typescript-wc-template/?tab=readme-ov-file#releasing-production-level-package) re: starting tags at 1. Includes a change to the form warning messages for email and screenname.